### PR TITLE
Skip progress if no results returned

### DIFF
--- a/lib/stash-query/query.rb
+++ b/lib/stash-query/query.rb
@@ -219,7 +219,7 @@ module Stashquery
 
     puts res.inspect if $debug
 
-    if @config[:output]
+    if @config[:output] && @num_results > 0
       bar = ProgressBar.new(@num_results) if @config[:print]
       hit_list = Array.new
       total_lines = 0 if $debug


### PR DESCRIPTION
Otherwise progress bar is passed `0` and throws an exception ProgressBar::ArgumentError
