### PR TITLE
Support for configurable time-field name

### DIFF
--- a/bin/stash-query
+++ b/bin/stash-query
@@ -7,9 +7,10 @@ require 'stash-query'
 $config = {}
 $config[:host] = "localhost"
 $config[:port] = "9200"
+$config[:timefield] = "@timestamp"
 $config[:index_prefix] = [ "logstash-" ]
 $config[:scroll_size] = 10  ## Number of hits returned per scroll request. Not sure what to use here...
-$config[:scroll_time] = '30m'   
+$config[:scroll_time] = '30m'
 $config[:report] = nil
 $config[:write_fields] = []
 $config[:delim] = ','
@@ -23,22 +24,23 @@ OptionParser.new do |opts|
   opts.banner = "Usage: "
   opts.on('-c','--connect_host [HOST]', "Elasticsearch host to run query on (defaults to: #{$config[:host]})") { |v| $config[:host] = v unless v.empty? or v.nil? }
   opts.on('-p','--port [PORT]', "Elasticsearch port (defaults to: #{$config[:port]})") { |v| $config[:port] = v unless v.empty? or v.nil? }
+  opts.on('-T','--timefield [FIELDNAME]', "Time-field name (defaults to: #{$config[:timefield]})") { |v| $config[:timefield] = v unless v.empty? or v.nil? }
   opts.on('-i','--index-prefix [PREFIX]', "Index name prefix(es). Defaults to 'logstash-'. Comma delimited") do |prefix|
     $config[:index_prefix] = prefix.split(',') unless prefix.empty? or prefix.nil?
   end
   opts.on('-w', '--write [FILE]', 'Write output file location (defaults to nil)') { |v| $config[:output] = v }
   opts.on('-d', '--debug', 'Debug mode') { |v| $debug = true }
 
-  opts.on('-s', '--start [DATE]', 'Start date. Format: YYYY-MM-DDThh:mm:ss.SSSZ. Ex: 2013-12-01T12:00:00.000Z') do |v| 
+  opts.on('-s', '--start [DATE]', 'Start date. Format: YYYY-MM-DDThh:mm:ss.SSSZ. Ex: 2013-12-01T12:00:00.000Z') do |v|
     $config[:start] = v
   end
 
-  opts.on('-e', '--end [DATE]', 'End date. Format: YYYY-MM-DDThh:mm:ss.SSSZ') do |v| 
+  opts.on('-e', '--end [DATE]', 'End date. Format: YYYY-MM-DDThh:mm:ss.SSSZ') do |v|
     $config[:end] = v
   end
 
   opts.on('-q', '--query [QUERY]', 'Query string') { |v| $config[:query] = "#{v}" unless v.empty? }
-  opts.on('-t', '--tags [TAGS]', 'Tags to query. Comma delimited')  do |tags|  
+  opts.on('-t', '--tags [TAGS]', 'Tags to query. Comma delimited')  do |tags|
     arr = tags.split(',')
     if arr.length > 1
       $config[:tags] = "tags:(" + arr.join(' AND ') + ")"
@@ -63,6 +65,7 @@ es_conf = {
   :output_file => $config[:output],
   :host => $config[:host],
   :port => $config[:port],
+  :timefield => $config[:timefield],
   :index_prefixes => $config[:index_prefix],
   :write_fields => $config[:write_fields],
   :delimiter => $config[:delim],

--- a/lib/stash-query/query.rb
+++ b/lib/stash-query/query.rb
@@ -25,6 +25,7 @@ module Stashquery
     @config = {}
     @config[:host] = conf[:host] || "ls2-es-lb.int.tropo.com"
     @config[:port] = conf[:port] || "9200"
+    @config[:timefield] = conf[:timefield] || "@timestamp"
     if conf[:index_prefixes].is_a? Array and ! conf[:index_prefixes].empty?
       @config[:index_prefixes] = conf[:index_prefixes]
     else
@@ -61,7 +62,6 @@ module Stashquery
       rescue
       end
     end
-
     @es_conn = connect_to_es
     run_query
     sort_file
@@ -187,7 +187,7 @@ module Stashquery
     queries << @tags if @tags
 
     if @start_date and @end_date
-      time_range = "@timestamp:[#{@start_date} TO #{@end_date}]"
+      time_range = "#{@config[:timefield]}:[#{@start_date} TO #{@end_date}]"
       queries << "#{time_range}"
       indexes = get_indices
     else


### PR DESCRIPTION
With this change it is possible to support time-field names different than @timestamp to support non Logstash setups.
I've added a new optional flag -T --timefield that defaults to @timestamp


