### PR TITLE
SSL and other fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,12 @@ Examples:
 ```
 stash-query -s 2013-12-01T00:00:00.000Z -e 2013-12-02T00:00:00.000Z -t my_tag -q 'message:hello_world' -w /tmp/my_query.txt
 ```
+
+#  To install locally
+
+```
+gem build stash-query.gemspec
+ 
+gem install stash-query-<version>.gem
+```
+

--- a/README.md
+++ b/README.md
@@ -3,11 +3,16 @@ stash-query
 
 A CLI Tool for Querying Logstash/Elasticsearch and Exporting the results. Uses the Lucene query syntax that Kibana utilizes, but provides the option for exporting. 
 
-Usage:
+Usage: 
 ```
     -c, --connect_host [HOST]        Elasticsearch host to run query on (defaults to: localhost)
     -p, --port [PORT]                Elasticsearch port (defaults to: 9200)
-    -i, --index-prefix [PREFIX]      Index name prefix. Defaults to 'logstash-'
+        --ssl                        Elasticsearch port (defaults to no ssl)
+    -T, --timefield [FIELDNAME]      Time-field name (defaults to: @timestamp)
+        --scroll-size [number of records]
+                                     Scroll Size (defaults to: 10).
+        --scroll-time [time units]   Scroll Size (defaults to: 30m).
+    -i, --index-prefix [PREFIX]      Index name prefix(es). Defaults to 'logstash-'. Comma delimited
     -w, --write [FILE]               Write output file location (defaults to nil)
     -d, --debug                      Debug mode
     -s, --start [DATE]               Start date. Format: YYYY-MM-DDThh:mm:ss.SSSZ. Ex: 2013-12-01T12:00:00.000Z
@@ -16,6 +21,8 @@ Usage:
     -t, --tags [TAGS]                Tags to query. Comma delimited
     -f, --write-fields [FIELDS]      Comma delimited list of Logstash fields to write to output file. Defaults to "message"
     -l, --delimiter [DELIMITER]      Delimiter to use in output file. Defaults to ","
+    -S, --silent                     Run silently
+    -m, --max [INTEGER]              Maximum number of results to return. Non-integer arguments default to 0.
 ```
 
 Examples:

--- a/bin/stash-query
+++ b/bin/stash-query
@@ -29,6 +29,12 @@ OptionParser.new do |opts|
   opts.on('-p','--port [PORT]', "Elasticsearch port (defaults to: #{$config[:port]})") { |v| $config[:port] = v unless v.empty? or v.nil? }
   opts.on('--ssl', "Elasticsearch port (defaults to no ssl)") { |v| $config[:scheme] = 'https' }
   opts.on('-T','--timefield [FIELDNAME]', "Time-field name (defaults to: #{$config[:timefield]})") { |v| $config[:timefield] = v unless v.empty? or v.nil? }
+  opts.on('--scroll-size [number of records]', "Scroll Size (defaults to: #{$config[:scroll_size]}).") do |v|
+    $config[:scroll_size] = v unless v.empty? or v.nil?
+  end
+  opts.on('--scroll-time [time units]', "Scroll Size (defaults to: #{$config[:scroll_time]}).") do |v|
+    $config[:scroll_time] = v unless v.empty? or v.nil?
+  end
   opts.on('-i','--index-prefix [PREFIX]', "Index name prefix(es). Defaults to 'logstash-'. Comma delimited") do |prefix|
     $config[:index_prefix] = prefix.split(',') unless prefix.empty? or prefix.nil?
   end

--- a/bin/stash-query
+++ b/bin/stash-query
@@ -36,7 +36,7 @@ OptionParser.new do |opts|
     $config[:scroll_time] = v unless v.empty? or v.nil?
   end
   opts.on('-i','--index-prefix [PREFIX]', "Index name prefix(es). Defaults to 'logstash-'. Comma delimited") do |prefix|
-    $config[:index_prefix] = prefix.split(',') unless prefix.empty? or prefix.nil?
+    $config[:index_prefixes] = prefix.split(',') unless prefix.empty? or prefix.nil?
   end
   opts.on('-w', '--write [FILE]', 'Write output file location (defaults to nil)') { |v| $config[:output_file] = v }
   opts.on('-d', '--debug', 'Debug mode') { |v| $config[:debug] = true }

--- a/bin/stash-query
+++ b/bin/stash-query
@@ -6,6 +6,7 @@ require 'stash-query'
 ############ CONFIG ###########
 $config = {}
 $config[:host] = "localhost"
+$config[:scheme] = "http"
 $config[:port] = "9200"
 $config[:timefield] = "@timestamp"
 $config[:index_prefix] = [ "logstash-" ]
@@ -26,6 +27,7 @@ OptionParser.new do |opts|
   opts.banner = "Usage: "
   opts.on('-c','--connect_host [HOST]', "Elasticsearch host to run query on (defaults to: #{$config[:host]})") { |v| $config[:host] = v unless v.empty? or v.nil? }
   opts.on('-p','--port [PORT]', "Elasticsearch port (defaults to: #{$config[:port]})") { |v| $config[:port] = v unless v.empty? or v.nil? }
+  opts.on('--ssl', "Elasticsearch port (defaults to no ssl)") { |v| $config[:scheme] = 'https' }
   opts.on('-T','--timefield [FIELDNAME]', "Time-field name (defaults to: #{$config[:timefield]})") { |v| $config[:timefield] = v unless v.empty? or v.nil? }
   opts.on('-i','--index-prefix [PREFIX]', "Index name prefix(es). Defaults to 'logstash-'. Comma delimited") do |prefix|
     $config[:index_prefix] = prefix.split(',') unless prefix.empty? or prefix.nil?

--- a/lib/stash-query/query.rb
+++ b/lib/stash-query/query.rb
@@ -217,7 +217,7 @@ module Stashquery
     puts "Using these indices: #{indexes.join(',')}" if @config[:debug]
 
     index_str = indexes.join(',')
-    res = @es_conn.search index: index_str, q: query, search_type: 'scan', scroll: @config[:scroll_time], size: @config[:scroll_size], df: 'message'
+    res = @es_conn.search index: index_str, q: query, scroll: @config[:scroll_time], size: @config[:scroll_size], df: 'message'
     scroll_id = res['_scroll_id']
 
     @scroll_ids << res['_scroll_id']

--- a/lib/stash-query/query.rb
+++ b/lib/stash-query/query.rb
@@ -250,14 +250,14 @@ module Stashquery
         res['hits']['hits'].each do |hit|
           bar.increment! if @config[:print]
           hit_list << hit
-	  if @config[:max_results]
-            # Set break flag
-	    if hit_list.length == @config[:max_results]
+      	  if @config[:max_results]
+                  # Set break flag
+      	    if hit_list.length == @config[:max_results]
               puts "Hit max result limit: #{@config[:max_results]} records" if @config[:debug]
-	      $break_while_loop = true
-	      break
-	    end
-	  end
+      	      $break_while_loop = true
+      	      break
+      	    end
+      	  end
           if hit_list.length % $flush_buffer == 0
             @config[:output] ? flush_to_file(hit_list) : (puts generate_output(hit_list))
             hit_list = Array.new

--- a/lib/stash-query/version.rb
+++ b/lib/stash-query/version.rb
@@ -1,3 +1,3 @@
 module Stashquery
-  VERSION = '0.1.3'
+  VERSION = '0.1.3-SNAPSHOT'
 end


### PR DESCRIPTION
Add support for Elastic Search clusters that require SSL
add options for configuring scoll-time and scroll-size options
fix --index-prefix option that was not honored
do not try to use search_type=scan that was removed in ES5.5. 
